### PR TITLE
Updated to bevy main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "bevy"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_internal",
 ]
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "bevy-crevice-derive"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -160,7 +160,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -173,7 +173,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "bevy_core"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_derive",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "bevy_crevice"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy-crevice-derive",
  "bytemuck",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -270,7 +270,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "async-channel",
  "bevy_ecs_macros",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "anyhow",
  "base64",
@@ -322,7 +322,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -333,7 +333,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -378,7 +378,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "cargo-manifest",
  "quote",
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_reflect",
  "glam",
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_reflect_derive",
  "bevy_utils",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -498,7 +498,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "ahash",
  "bevy_derive",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_math",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.6.0"
-source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
+source = "git+https://github.com/bevyengine/bevy.git?rev=b697e73c3d861c209152ccfb140ae00fbc6e9925#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "approx",
  "bevy_app",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61caed9aec6daeee1ea38ccf5fb225e4f96c1eeead1b4a5c267324a63cf02326"
+checksum = "d54a65e0d4f66f8536c98cb3ca81ca33b7e2ca43442465507a3a62291ec0d9e4"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "approx"
@@ -128,9 +128,9 @@ checksum = "677d306121baf53310a3fd342d88dc0824f6bbeace68347593658525565abee8"
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -141,8 +141,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "bevy"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77ad2987710ed960746c43813ad8c103db5c4c090f5cbc9c32c0a90a91bc599"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_internal",
 ]
@@ -150,8 +149,7 @@ dependencies = [
 [[package]]
 name = "bevy-crevice-derive"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cf594c9277eb1e426f45a00eaf70aa9ffdf479268d7e4538270263811e20bc"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -162,8 +160,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fe3d3f4140fb11cd294f43be7cb66a5783d9277ba0270743e2860e32b25ab5"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -176,8 +173,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb68a0259e2f857a32c4f05eb9b9447db1072297c61864ad07d02fea1838bde9"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -213,8 +209,7 @@ dependencies = [
 [[package]]
 name = "bevy_core"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c156430a5312c04a1b25fa434eeeab6349a41c6bb96ea0385406d53b3c43658"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_derive",
@@ -229,21 +224,20 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b422dca94195c904964ab21bc4557fbd11f692c299d46e38364715ac931841e"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_ecs",
  "bevy_render",
+ "bevy_utils",
 ]
 
 [[package]]
 name = "bevy_crevice"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d3eeb3237df793e8e01a110ee71824eacd15421821f9b175f3bafca864614c"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy-crevice-derive",
  "bytemuck",
@@ -254,8 +248,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918dc0dff01e8b4e8f989db89d74fd4042810ea80a70642d0459b3c265995e59"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -265,8 +258,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbe98f48873d4b20f6479723de18d957f4bc00c653efd36c245e6a66d6e8b71"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -278,8 +270,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b182092396e6c2caf5ab30d738511fcd382628aa86ef35878d28fabb325c933"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "async-channel",
  "bevy_ecs_macros",
@@ -296,8 +287,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e9e664b3ea45cfc9ab3251ee0255dfa6410f675b3a405e7bac8e59b2d76aa9"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -308,8 +298,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4711f4f77542dccd59eec249c98f02e34e28a25ee079c14cd351061d08e5c"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "anyhow",
  "base64",
@@ -333,8 +322,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33989693efa636960dd40e540029ed7b7bc1af2f3eef26c009555b5e2a4e185a"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -345,8 +333,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92af28d95bba80d11840c24fa4ce8ff84ae27af1def2f5cf8a6891acce5d714"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -377,8 +364,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf0083e72bf76cbfa6607311ac6baef2f4f7c9306c35942cece8c0589cd3e5e"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -392,8 +378,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf90b3b67606d0818cdac6c9134eb66fa174959977a4abba893364a571a7cd"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "cargo-manifest",
  "quote",
@@ -403,8 +388,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0f9ebf2ef80a8fff3e5dca817594071004048cd089e72b9a1bf4e494b66112"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_reflect",
  "glam",
@@ -413,8 +397,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5c00c4d1d806a93caf554c28ca9708cc6717463a63dd400e70b106918bd32c"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -434,8 +417,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84ce8cbd484a39d67171831eaf72c20d2684de71f1e9d79333c8dd6d6f3ebca"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_reflect_derive",
  "bevy_utils",
@@ -451,8 +433,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af3100febf44583a7c052d1469fbdb411f56aa85729333a0ac106a016bd379c"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -464,8 +445,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4175b9afe0963d04d485980438f631c1e2b02d3a57f58503b8e9239c44d5c2bf"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -500,8 +480,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eb2b01e4d1b074c75ea59a92409739cac24b56b1c723491ef80936d50e95df"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -519,8 +498,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66439831ff57c11c7fb2692e7ccf8d0551f4368a9908908d3c38f2da53115b33"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -545,8 +523,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc4bce7f4cddbb489636092f52478b103dc26ee8526c585289bbdd9c0d0a99f"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -559,8 +536,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233c4bb933435e8e6c34a1310317fd7f8c6617526270de572e643816070b236a"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -583,8 +559,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9974c494f9cc721df46d2ba27c6a8df2a955ed8360a23adabd2bd66d1f73fa8f"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -597,8 +572,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f30583acee76b40bf1961ece57887ba067becc1e4694ef5dddf18ce2c038886"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -625,12 +599,12 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252f6674aa3ba68bacfec506b91570a3cc206ad09b7ef4b23661959ef0246396"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "ahash",
  "bevy_derive",
  "getrandom",
+ "hashbrown",
  "instant",
  "tracing",
  "uuid",
@@ -639,8 +613,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4b52b766baf565e96f24f61dbc51bc85151f23202fed2b3650769f2edd0b21"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "bevy_app",
  "bevy_math",
@@ -652,8 +625,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699c927ef5422a09b71134e5907497117210fe5063676fc7250b7551926f4bba"
+source = "git+https://github.com/bevyengine/bevy.git#b697e73c3d861c209152ccfb140ae00fbc6e9925"
 dependencies = [
  "approx",
  "bevy_app",
@@ -756,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -787,7 +759,7 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics 0.22.3",
  "foreign-types",
  "libc",
@@ -802,7 +774,7 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -862,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys 0.8.3",
  "libc",
@@ -901,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -914,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "foreign-types",
  "libc",
 ]
@@ -944,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -1097,15 +1069,15 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -1133,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1169,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "gltf"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff38b75359a0096dd0a8599b6e4f37a6ee41d5df300cc7669e62aafa697f7a2"
+checksum = "00e0a0eace786193fc83644907097285396360e9e82e30f81a21e9b1ba836a3e"
 dependencies = [
  "byteorder",
  "gltf-json",
@@ -1180,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "gltf-derive"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a9333e0f9c7bca94dfc20bcf44fa12a61eeec662d6e007563ff748aa59c70"
+checksum = "bdd53d6e284bb2bf02a6926e4cc4984978c1990914d6cd9deae4e31cf37cd113"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -1192,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "gltf-json"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1414d3a98cbaabdb2f134328b1f6036d14b282febc1df51952a435d2ca17fb6"
+checksum = "9949836a9ec5e7f83f76fb9bbcbc77f254a577ebbdb0820867bc11979ef97cad"
 dependencies = [
  "gltf-derive",
  "serde",
@@ -1269,6 +1241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
+ "serde",
 ]
 
 [[package]]
@@ -1297,9 +1270,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexasphere"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc62dcfd68ec810c4707804556f2e88655012b1a373b0e0bbbe88a9db366627"
+checksum = "04ab9d20ba513ff1582a7d885e91839f62cf28bef7c56b1b0428ca787315979b"
 dependencies = [
  "glam",
  "lazy_static",
@@ -1404,9 +1377,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libloading"
@@ -1506,9 +1479,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mint"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162e591484b4b8fe9e1ca16ebf07ab584fdc3334508d76a788cd54d89cfc20dc"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mio"
@@ -1566,16 +1539,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-glue"
-version = "0.5.0"
+name = "ndk-context"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc291b8de2095cba8dab7cf381bf582ff4c17a09acf854c32e46545b08085d28"
+checksum = "4e3c5cc68637e21fe8f077f6a1c9e0b9ca495bb74895226b476310f613325884"
+
+[[package]]
+name = "ndk-glue"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c68f70683c5fc9a747a383744206cd371741b2f0b31781ab6770487ec572e2"
 dependencies = [
  "android_logger",
  "lazy_static",
  "libc",
  "log",
  "ndk",
+ "ndk-context",
  "ndk-macro",
  "ndk-sys",
 ]
@@ -1625,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -1731,9 +1711,9 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef05f2882a8b3e7acc10c153ade2631f7bfc8ce00d2bf3fb8f4e9d2ae6ea5c3"
+checksum = "4fb1e509cfe7a12db2a90bfa057dfcdbc55a347f5da677c506b53dd099cfec9d"
 dependencies = [
  "ttf-parser",
 ]
@@ -1814,9 +1794,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml",
@@ -1848,14 +1828,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -1875,15 +1854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -2005,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -2177,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2189,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2200,11 +2170,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -2220,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -2249,15 +2220,15 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccbe8381883510b6a2d8f1e32905bddd178c11caef8083086d0c0c9ab0ac281"
+checksum = "c74c96594835e10fa545e2a51e8709f30b173a092bfd6036ef2cec53376244f3"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -2280,6 +2251,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -2577,7 +2554,7 @@ checksum = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
 dependencies = [
  "bitflags",
  "cocoa",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics 0.22.3",
  "core-video-sys",
  "dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ strum = "0.21.0"
 strum_macros = "0.21.1"
 
 [dependencies.bevy]
-version = "0.6"
+git = "https://github.com/bevyengine/bevy.git"
 features = ["render"]
 default-features = false
 
 [dev-dependencies.bevy]
-version = "0.6"
+git = "https://github.com/bevyengine/bevy.git"
 features = ["bevy_winit", "bevy_gltf"]
 default-features = false
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]
-version = "0.6"
+git = "https://github.com/bevyengine/bevy.git"
 features = ["x11", "wayland"]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,18 @@ strum_macros = "0.21.1"
 
 [dependencies.bevy]
 git = "https://github.com/bevyengine/bevy.git"
+rev = "b697e73c3d861c209152ccfb140ae00fbc6e9925"
 features = ["render"]
 default-features = false
 
 [dev-dependencies.bevy]
 git = "https://github.com/bevyengine/bevy.git"
+rev = "b697e73c3d861c209152ccfb140ae00fbc6e9925"
 features = ["bevy_winit", "bevy_gltf"]
 default-features = false
 
 [target.'cfg(target_os = "linux")'.dev-dependencies.bevy]
 git = "https://github.com/bevyengine/bevy.git"
+rev = "b697e73c3d861c209152ccfb140ae00fbc6e9925"
 features = ["x11", "wayland"]
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,10 +687,11 @@ fn player_look(
     let mut state_delta = state.as_mut();
     for (_camera, mut transform) in query.iter_mut() {
         for ev in state_delta.reader_motion.iter(&motion) {
-            
             if window.cursor_locked() {
-                state_delta.pitch -= (settings.sensitivity * ev.delta.y * window.height()).to_radians();
-                state_delta.yaw -= (settings.sensitivity * ev.delta.x * window.width()).to_radians();
+                state_delta.pitch -=
+                    (settings.sensitivity * ev.delta.y * window.height()).to_radians();
+                state_delta.yaw -=
+                    (settings.sensitivity * ev.delta.x * window.width()).to_radians();
             }
 
             state_delta.pitch = state_delta.pitch.clamp(-1.54, 1.54);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,18 +684,20 @@ fn player_look(
         return;
     }
     let window = windows.get_primary().unwrap();
+    let mut state_delta = state.as_mut();
     for (_camera, mut transform) in query.iter_mut() {
-        for ev in state.reader_motion.iter(&motion) {
+        for ev in state_delta.reader_motion.iter(&motion) {
+            
             if window.cursor_locked() {
-                state.pitch -= (settings.sensitivity * ev.delta.y * window.height()).to_radians();
-                state.yaw -= (settings.sensitivity * ev.delta.x * window.width()).to_radians();
+                state_delta.pitch -= (settings.sensitivity * ev.delta.y * window.height()).to_radians();
+                state_delta.yaw -= (settings.sensitivity * ev.delta.x * window.width()).to_radians();
             }
 
-            state.pitch = state.pitch.clamp(-1.54, 1.54);
+            state_delta.pitch = state_delta.pitch.clamp(-1.54, 1.54);
 
             // Order is important to prevent unintended roll
-            transform.rotation = Quat::from_axis_angle(Vec3::Y, state.yaw)
-                * Quat::from_axis_angle(Vec3::X, state.pitch);
+            transform.rotation = Quat::from_axis_angle(Vec3::Y, state_delta.yaw)
+                * Quat::from_axis_angle(Vec3::X, state_delta.pitch);
         }
     }
 }


### PR DESCRIPTION
Request to update to support bevy main #19
This is not suitable in the long term. 
However, since this is during the Bevy Jam # 1 and some might rely on `bevy_config_cam` I've made an exception.
I've also updated the master branch to main instead to align with the same naming convention as bevy's repository.